### PR TITLE
Remove need for GitHub token

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "wrench": "1.5.4",
     "github-releases": "0.1.1",
     "progress": "1.1.2",
-    "keytar": "1.x"
   },
   "licenses": [
     {


### PR DESCRIPTION
The relies on the following things after being merged:
- [x] Make atom/atom-shell public
- [x] Make this repo public
