### PR TITLE
Added example for grunt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ grunt.loadNpmTasks('grunt-download-atom-shell');
 * `symbols` - Download debugging symbols instead of binaries, default to `false`.
 * `rebuild` - Whether to rebuild native modules after atom-shell is downloaded.
 * `apm` - The path to apm.
+
+### Example
+
+    module.exports = function(grunt) {
+      grunt.initConfig({
+        download-atom-shell: {
+          version: '0.12.3',
+          outputDir: 'binaries'
+        }
+      });
+    };


### PR DESCRIPTION
Since grunt tasks are usually configured with an extra options object this plugin and the description in the `README.md` might be confusing. I added an example to the readme, to make it more clear where the task should be configured.
