### PR TITLE
Use current version of Atom Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ grunt.loadNpmTasks('grunt-download-atom-shell');
 module.exports = function(grunt) {
   grunt.initConfig({
     'download-atom-shell': {
-      version: '0.16.3',
+      version: '0.20.3',
       outputDir: 'binaries'
     }
   });


### PR DESCRIPTION
I keep seeing people using hella old versions of Atom Shell, this might have something to do with it
