### PR TITLE
Update github-releases to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "decompress-zip": "0.0.4",
     "grunt": "0.4",
     "wrench": "1.5.4",
-    "github-releases": "0.2.1",
+    "github-releases": "0.3.2",
     "progress": "1.1.2"
   },
   "licenses": [


### PR DESCRIPTION
This PR fixes two issues:
- github-releases versions below 0.3.1 required an outdated version of prettyjson that itself required a Node version <= 0.11.0 and would log a warning otherwise.
- Downloading releases from behind a proxy would fail with `Fatal error: Request path contains unescaped characters.`

Refs atom/atom#11525
